### PR TITLE
Change the broken links action 

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -16,7 +16,7 @@ jobs:
   check-site-for-broken-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: harrisonpim/broken-link-checker@0.2.1
+      - uses: fitzwilliammuseum/broken-link-checker@1.0.0
         with:
           sitemap: https://fitzmuseum.cam.ac.uk/sitemap.xml
           allowList: '["https://tickets.museums.cam.ac.uk/account/create","https://www.registrarysoffice.admin.cam.ac.uk/governance-and-strategy/anti-slavery-and-anti-trafficking","https://cubc.org.uk","https://www.linkedin.com/company/the-fitzwilliam-museum/"]'


### PR DESCRIPTION
Point to cloned fitz version of the link checker. This closes #476.
Test required via manual action - this has added in 302 test for redirects that produce false +ve for broken links (dirty fix.)