### PR TITLE
Fix: 360 image url

### DIFF
--- a/resources/views/includes/elements/galleries/360.blade.php
+++ b/resources/views/includes/elements/galleries/360.blade.php
@@ -10,5 +10,5 @@
     @endif
 @endsection
 @if(!empty($gallery['image_360_pano']))
-    @section('360_image', $gallery['image_360_pano']['data']['full_url'])
+    @section('360_image_url', $gallery['image_360_pano']['data']['full_url'])
 @endif


### PR DESCRIPTION
In the 360 blade view's code, the url pointing to the 360 imaged being used was incorrect, very simple fix to change the variable name. This closes #524 