### PR TITLE
Removed Islanders banner from visit-us/shopping-and-eating

### DIFF
--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -36,9 +36,6 @@
             @include('includes.structure.breadcrumb')
             @yield('press-contact')
             @yield('content')
-            @if(Request::is('visit-us/shopping-and-eating'))
-                @include('includes.elements.food-and-drink')
-            @endif
             @yield('adlib')
         </div>
         @yield('audioGuide')


### PR DESCRIPTION
Removed Islanders banner from visit-us/shopping-and-eating