### PR TITLE
Feat/rembrandt donate btn

### DIFF
--- a/resources/views/components/exhibition-cta.blade.php
+++ b/resources/views/components/exhibition-cta.blade.php
@@ -9,7 +9,7 @@
                 </a>
             @else
                 @if ($exhibition['slug'] == 'rembrandt-rubens-van-dyck')
-                    <a href="https://tickets.museums.cam.ac.uk/donate/i/donate-to-the-fitzwilliam" class="cta-btn">
+                    <a href="{{ url('support-us/make-a-donation') }}" class="cta-btn">
                         Donate now
                         @svg('fas-chevron-right', ['width' => '16px', 'height' => '16px', 'color' => '#fff'])
                     </a>

--- a/resources/views/components/exhibition-cta.blade.php
+++ b/resources/views/components/exhibition-cta.blade.php
@@ -8,7 +8,14 @@
                     @svg('fas-chevron-right', ['width' => '16px', 'height' => '16px', 'color' => '#fff'])
                 </a>
             @else
-                <p class="cta-btn">Tickets available soon...</p>
+                @if ($exhibition['slug'] == 'rembrandt-rubens-van-dyck')
+                    <a href="https://tickets.museums.cam.ac.uk/donate/i/donate-to-the-fitzwilliam" class="cta-btn">
+                        Donate now
+                        @svg('fas-chevron-right', ['width' => '16px', 'height' => '16px', 'color' => '#fff'])
+                    </a>
+                @else
+                    <p class="cta-btn">Tickets available soon...</p>
+                @endif
             @endif
             <a class="exhibition-cta-link" href="/plan-your-visit">Plan your visit</a>
         </div>


### PR DESCRIPTION
https://studio24.zendesk.com/agent/tickets/14354

```
We’re are planning to publish a new page on Tuesday the 30th for the opening of a new display 'Rembrandt, Rubens, Van Dyck' which is now saved as a draft in the CMS.

Would it be possible to amend the copy on the button which pulls through in the top left of the page? – it currently says 'Book now' and links to the ticket page. But for this display, we need the button to read ‘Donate now’. And for it to link to the ‘Make a donation’ webpage in place of ticketing.
```

https://fitzmuseum.studio24.dev/plan-your-visit/exhibitions/rembrandt-rubens-van-dyck