### PR TITLE
Hotfix/related content removal

### DIFF
--- a/resources/views/exhibitions/details.blade.php
+++ b/resources/views/exhibitions/details.blade.php
@@ -91,7 +91,7 @@
 
     @include('includes.elements.exhibitions.events-url')
 
-    @include('includes.elements.exhibitions.similar-exhibits')
+    {{-- @include('includes.elements.exhibitions.similar-exhibits') --}}
 
 {{-- End template check --}}
 @endif

--- a/resources/views/news/article.blade.php
+++ b/resources/views/news/article.blade.php
@@ -63,7 +63,7 @@
 @endsection
 
 @section('mlt')
-@if(!empty($records))
+{{-- @if(!empty($records))
 <div class="container">
     <h3>Other recommended articles</h3>
     <div class="row">
@@ -72,5 +72,5 @@
         @endforeach
     </div>
 </div>
-@endif
+@endif --}}
 @endsection


### PR DESCRIPTION
Client asked in [this trello card ](https://trello.com/c/fyibCIKx/73-remove-related-content-across-all-pages) to remove the random "Related content" cards that appear at the foot of the old exhibition pages and news articles. 

I commented this component out of the template for those two content types.