### PR TITLE
paris exhibition cta 

### DIFF
--- a/resources/views/components/exhibition-cta.blade.php
+++ b/resources/views/components/exhibition-cta.blade.php
@@ -20,6 +20,11 @@
                 Donate now
                 @svg('fas-chevron-right', ['width' => '16px', 'height' => '16px', 'color' => '#fff'])
             </a>
+        @elseif($exhibition['slug'] == 'paris-1924-sport-art-and-the-body')
+            <a href="{{ url('https://tickets.museums.cam.ac.uk/overview/8294') }}" class="cta-btn">
+                Book now
+                @svg('fas-chevron-right', ['width' => '16px', 'height' => '16px', 'color' => '#fff'])
+            </a>
         @elseif(!empty($exhibition['exhibition_url']))
             <a href="{{ $exhibition['exhibition_url'] }}" class="cta-btn">
                 Book now


### PR DESCRIPTION
Client requested to change 'Paris 1924 Sport, Art and Body' exhibition CTA button text and link url.

Just to note, currently on staging this exhibition is created using `old exhibition template` so it won't be available until re-created using new `exhibition-2024` template.

This PR will be merged to staging branch.

REF: https://studio24.zendesk.com/agent/tickets/14401

