### PR TITLE
image url

### DIFF
--- a/resources/views/components/governance-card.blade.php
+++ b/resources/views/components/governance-card.blade.php
@@ -1,7 +1,7 @@
 <div class="col-md-4 mb-3">
     <div class="card card-fitz h-100">
         @isset($image['data']['thumbnails'])
-            <a href="{{ $image['data']['full_url'] }}">
+            <a href="{{ $file['data']['full_url'] }}">
                 <img class="card-img-top"
                      src="{{ $image['data']['thumbnails'][13]['url']}}"
                      alt="{{ $altTag }}"


### PR DESCRIPTION
Governance card image url change

https://fitzmuseum.studio24.dev/about-us/governance-policies-and-reports

Each card image should link to appropriate document

REF: https://studio24.zendesk.com/agent/tickets/14434