### PR TITLE
Try excluding social media from search results

### DIFF
--- a/app/Http/Controllers/highlightsController.php
+++ b/app/Http/Controllers/highlightsController.php
@@ -158,6 +158,12 @@ class highlightsController extends Controller
 
         $number = $data->getNumFound();
         $records = $data->getDocuments();
+        foreach($records as $index=>$record) {
+            $url = $record['url']['0'];
+            if(str_contains($url, 'x.com') || str_contains($url, 'facebook.com') || str_contains($url, 'linkedin.com') || str_contains($url, 'youtube.com') || str_contains($url, 'instagram.com') ) {
+                unset($records[$index]);
+            }
+        }
         $paginate = new LengthAwarePaginator($records, $number, $perPage);
         $paginate->setPath($request->getBaseUrl() . '?query=' . $queryString);
         return view('highlights.results', compact('records', 'number', 'paginate', 'queryString'));

--- a/resources/views/highlights/results.blade.php
+++ b/resources/views/highlights/results.blade.php
@@ -19,7 +19,7 @@
     @php
         $url = $result['url'][0];
         $is_social = false;
-        if(str_contains($url, 'twitter') || str_contains($url, 'facebook') || str_contains($url, 'linkedin') || str_contains($url, 'youtube') ) {
+        if(str_contains($url, 'x.com') || str_contains($url, 'facebook') || str_contains($url, 'linkedin') || str_contains($url, 'youtube') ) {
             $is_social = true;
         }
     @endphp

--- a/resources/views/highlights/results.blade.php
+++ b/resources/views/highlights/results.blade.php
@@ -14,7 +14,7 @@
     @php
         $url = $result['url'][0];
         $is_social = false;
-        if(str_contains($url, 'x.com') || str_contains($url, 'facebook') || str_contains($url, 'linkedin') || str_contains($url, 'youtube') || str_contains($url, 'instagram') ) {
+        if(str_contains($url, 'x.com') || str_contains($url, 'facebook.com') || str_contains($url, 'linkedin.com') || str_contains($url, 'youtube.com') || str_contains($url, 'instagram.com') ) {
             $is_social = true;
         }
         if($is_social === true) {
@@ -32,7 +32,7 @@
 @if(!empty($records))
 <div class="row">
     @foreach($records as $result)
-    {{-- Only display results if their url  --}}
+    {{-- Only display results if their url doesn't go to social media  --}}
     @php
         $url = $result['url'][0];
         $is_social = false;

--- a/resources/views/highlights/results.blade.php
+++ b/resources/views/highlights/results.blade.php
@@ -7,22 +7,6 @@
 @section('content')
 
 <h2>Search results</h2>
- {{-- If search results lead to social media websites, don't include them in the final results number --}}
- {{-- As they're set not to show up in the result cards --}}
-@if(!empty($records))
-    @foreach($records as $result)
-    @php
-        $url = $result['url'][0];
-        $is_social = false;
-        if(str_contains($url, 'x.com') || str_contains($url, 'facebook.com') || str_contains($url, 'linkedin.com') || str_contains($url, 'youtube.com') || str_contains($url, 'instagram.com') ) {
-            $is_social = true;
-        }
-        if($is_social === true) {
-            $number = $number -= 1;
-        }
-    @endphp
-    @endforeach
-@endif
 <div class="col-12 col-max-800 shadow-sm p-3 mx-auto mb-3">
     <p>
         Your search for <strong>{{ $queryString }}</strong> returned <strong>{{ $number }}</strong> results.
@@ -32,17 +16,7 @@
 @if(!empty($records))
 <div class="row">
     @foreach($records as $result)
-    {{-- Only display results if their url doesn't go to social media  --}}
-    @php
-        $url = $result['url'][0];
-        $is_social = false;
-        if(str_contains($url, 'x.com') || str_contains($url, 'facebook.com') || str_contains($url, 'linkedin.com') || str_contains($url, 'youtube.com') || str_contains($url, 'instagram.com') ) {
-            $is_social = true;
-        }
-    @endphp
-    @if(!$is_social)
         <x-solr-card :result="$result"></x-solr-card>
-    @endif
     @endforeach
 </div>
 <nav aria-label="Page navigation">

--- a/resources/views/highlights/results.blade.php
+++ b/resources/views/highlights/results.blade.php
@@ -19,7 +19,7 @@
     @php
         $url = $result['url'][0];
         $is_social = false;
-        if(str_contains($url, 'x.com') || str_contains($url, 'facebook') || str_contains($url, 'linkedin') || str_contains($url, 'youtube') ) {
+        if(str_contains($url, 'x.com') || str_contains($url, 'facebook') || str_contains($url, 'linkedin') || str_contains($url, 'youtube') || str_contains($url, 'instagram') ) {
             $is_social = true;
         }
     @endphp

--- a/resources/views/highlights/results.blade.php
+++ b/resources/views/highlights/results.blade.php
@@ -7,6 +7,22 @@
 @section('content')
 
 <h2>Search results</h2>
+ {{-- If search results lead to social media websites, don't include them in the final results number --}}
+ {{-- As they're set not to show up in the result cards --}}
+@if(!empty($records))
+    @foreach($records as $result)
+    @php
+        $url = $result['url'][0];
+        $is_social = false;
+        if(str_contains($url, 'x.com') || str_contains($url, 'facebook') || str_contains($url, 'linkedin') || str_contains($url, 'youtube') || str_contains($url, 'instagram') ) {
+            $is_social = true;
+        }
+        if($is_social === true) {
+            $number = $number -= 1;
+        }
+    @endphp
+    @endforeach
+@endif
 <div class="col-12 col-max-800 shadow-sm p-3 mx-auto mb-3">
     <p>
         Your search for <strong>{{ $queryString }}</strong> returned <strong>{{ $number }}</strong> results.
@@ -16,10 +32,11 @@
 @if(!empty($records))
 <div class="row">
     @foreach($records as $result)
+    {{-- Only display results if their url  --}}
     @php
         $url = $result['url'][0];
         $is_social = false;
-        if(str_contains($url, 'x.com') || str_contains($url, 'facebook') || str_contains($url, 'linkedin') || str_contains($url, 'youtube') || str_contains($url, 'instagram') ) {
+        if(str_contains($url, 'x.com') || str_contains($url, 'facebook.com') || str_contains($url, 'linkedin.com') || str_contains($url, 'youtube.com') || str_contains($url, 'instagram.com') ) {
             $is_social = true;
         }
     @endphp

--- a/resources/views/highlights/results.blade.php
+++ b/resources/views/highlights/results.blade.php
@@ -16,7 +16,16 @@
 @if(!empty($records))
 <div class="row">
     @foreach($records as $result)
-    <x-solr-card :result="$result"></x-solr-card>
+    @php
+        $url = $result['url'][0];
+        $is_social = false;
+        if(str_contains($url, 'twitter') || str_contains($url, 'facebook') || str_contains($url, 'linkedin') || str_contains($url, 'youtube') ) {
+            $is_social = true;
+        }
+    @endphp
+    @if(!$is_social)
+        <x-solr-card :result="$result"></x-solr-card>
+    @endif
     @endforeach
 </div>
 <nav aria-label="Page navigation">


### PR DESCRIPTION
This pull request is an intended solution to the [Trello card](https://trello.com/c/iFuurKna/89-search-results-page-removing-social-media-results) about removing social media results from the site search

This code looks for strings containing the names of social media (e.g twitter, facebook, youtube, linkedin, instagram) and sets a `is_social` variable to true if so. 
This then allows us to only display result cards when the `is_social` variable is false.
It also allows us to exclude social media results from the final reported number of search results.

As SOLR isn't enabled on staging and cannot be tested locally, this has not been tested on any environment. As such, anything you can spot that might blow up if it gets pushed to production would be welcomely reported!