### PR TITLE
fix: files component add to new exhibition template

### DIFF
--- a/resources/views/exhibitions/templates/details-2024.blade.php
+++ b/resources/views/exhibitions/templates/details-2024.blade.php
@@ -17,8 +17,11 @@
 <x-exhibition-cta :exhibition="$exhibition"></x-exhibition-cta>
 
 @include('support.components.components-repeater', ['page' => $exhibition])
-
 {{-- {{ dd($exhibition) }} --}}
+
+@if (!empty($exhibition['exhibition_files']))
+    @include('includes.elements.exhibitions.files')
+@endif
 
 @if($reposition_curators == false && (!empty($exhibition['associated_curators']) || !empty($exhibition['external_curators'])))
     @include('exhibitions.components.curators')

--- a/resources/views/includes/elements/exhibitions/files.blade.php
+++ b/resources/views/includes/elements/exhibitions/files.blade.php
@@ -1,5 +1,11 @@
-@section('exhibitions-files')
-    @if(!empty($exhibition['exhibition_files']))
+@if (!empty($page_template))
+    @if (!empty($exhibition['exhibition_files']))
         <x-exhibition-files :files="$exhibition['exhibition_files']"></x-exhibition-files>
     @endif
-@endsection
+@else
+    @section('exhibitions-files')
+        @if (!empty($exhibition['exhibition_files']))
+            <x-exhibition-files :files="$exhibition['exhibition_files']"></x-exhibition-files>
+        @endif
+    @endsection
+@endif


### PR DESCRIPTION
Client has been unable to see files component which includes associated files for an exhibition.

This has been deployed to staging.

https://fitzmuseum.studio24.dev/plan-your-visit/exhibitions/paris-1924-sport-art-and-the-body

ref: https://studio24.zendesk.com/agent/tickets/14475