### PR TITLE
Introduce new related_documents field to directus for exhibition file…

### DIFF
--- a/resources/views/exhibitions/templates/details-2024.blade.php
+++ b/resources/views/exhibitions/templates/details-2024.blade.php
@@ -17,10 +17,9 @@
 <x-exhibition-cta :exhibition="$exhibition"></x-exhibition-cta>
 
 @include('support.components.components-repeater', ['page' => $exhibition])
-{{-- {{ dd($exhibition) }} --}}
 
-@if (!empty($exhibition['exhibition_files']))
-    @include('includes.elements.exhibitions.files')
+@if (!empty($exhibition['related_documents']))
+    @include('includes.elements.exhibitions.files', ['source' => $exhibition['related_documents']])
 @endif
 
 @if($reposition_curators == false && (!empty($exhibition['associated_curators']) || !empty($exhibition['external_curators'])))

--- a/resources/views/includes/elements/exhibitions/files.blade.php
+++ b/resources/views/includes/elements/exhibitions/files.blade.php
@@ -1,11 +1,8 @@
-@if (!empty($page_template))
-    @if (!empty($exhibition['exhibition_files']))
-        <x-exhibition-files :files="$exhibition['exhibition_files']"></x-exhibition-files>
-    @endif
-@else
-    @section('exhibitions-files')
-        @if (!empty($exhibition['exhibition_files']))
-            <x-exhibition-files :files="$exhibition['exhibition_files']"></x-exhibition-files>
-        @endif
-    @endsection
+@if(!isset($source))
+    @php
+        $source = $exhibition['exhibition_files']
+    @endphp
+@endif
+@if(!empty($source))
+    <x-exhibition-files :files="$source"></x-exhibition-files>
 @endif


### PR DESCRIPTION
…s to live

This work is a solution to ticket #14475 on Zendesk and adds support for a new field named "Related Documents" and does the following:

- Changes the empty check in `exhibitions/templates/details-2024.blade.php` from `$exhibition['exhibition_files']` to `$exhibition['related_documents']` so that the `related_documents` field is _**only**_ used by the new template

- Introduces the `$source` variable that's initialised and given a default value in the `exhibitions/files.blade.php` file and passed a custom value in the `@include` in `details-2024.blade.php` to simplify the template code.

This work has been deployed to staging and approved by the client for deployment to production.