### PR TITLE
Assume end of day for job vacancy expiration dates.

### DIFF
--- a/resources/views/aboutus/vacancy.blade.php
+++ b/resources/views/aboutus/vacancy.blade.php
@@ -14,7 +14,7 @@
 
 @section('content')
     <div class="col-12 shadow-sm p-3 mx-auto mb-3 article">
-        @if(Carbon\Carbon::parse($vacancy['expires'])->isPast())
+        @if(Carbon\Carbon::parse($vacancy['expires'])->endOfDay()->isPast())
             @include('includes.structure.jobexpired')
         @endif
         @if(isset($vacancy['salary_range']))
@@ -30,7 +30,7 @@
         @endisset
         @markdown($vacancy['job_description'])
 
-    @if(!Carbon\Carbon::parse($vacancy['expires'])->isPast())
+    @if(!Carbon\Carbon::parse($vacancy['expires'])->endOfDay()->isPast())
     @include('includes.structure.jobLink')
     @endif
 

--- a/resources/views/components/vacancy.blade.php
+++ b/resources/views/components/vacancy.blade.php
@@ -10,7 +10,7 @@
                      loading="lazy"/>
             </a>
         @endif
-        @if(Carbon\Carbon::parse($vacancy['expires'])->isPast())
+        @if(Carbon\Carbon::parse($vacancy['expires'])->endOfDay()->isPast())
             @include('includes.structure.jobexpired')
         @endif
         <div class="card-body h-100">


### PR DESCRIPTION
If a vacancy's expiration date was 2024-12-19, it would have previously been expired from 00:00:01 that day. This change makes them expire at 23:59:59 instead.

Allows the vacancy to still be available to apply on the day it's listed to expire.

Testing on staging: https://fitzmuseum.studio24.dev/about-us/work-with-us/details/head-of-curatorial