### PR TITLE
Hotfix/published exhibitions

### DIFF
--- a/app/Models/Exhibitions.php
+++ b/app/Models/Exhibitions.php
@@ -156,7 +156,6 @@ class Exhibitions extends Model
                 'fields' => '*.*.*.*',
                 'filter[exhibition_status][eq]' => $status,
                 'meta' => 'result_count,total_count,type',
-                'filter[status][eq]' => 'published',
                 'sort' => $sort,
                 'limit' => $limit
             )
@@ -175,6 +174,7 @@ class Exhibitions extends Model
             array(
                 'fields' => '*.*.*.*.*.*',
                 'filter[slug][eq]' => $slug,
+                'filter[status][eq]' => 'published',
                 'meta' => '*'
             )
         );
@@ -226,6 +226,7 @@ class Exhibitions extends Model
             array(
                 'fields' => '*.*.*.*',
                 'filter[associated_people_id][in]' => $curator,
+                'filter[status][eq]' => 'published',
             )
         );
         return $api->getData();

--- a/app/Models/Exhibitions.php
+++ b/app/Models/Exhibitions.php
@@ -22,6 +22,7 @@ class Exhibitions extends Model
             array(
                 'fields' => '*.*.*.*',
                 'filter[exhibition_status][eq]' => $status,
+                'filter[status][eq]' => 'published',
                 'filter[type][eq]' => $type,
                 'meta' => '*',
                 'sort' => $sort,
@@ -44,6 +45,7 @@ class Exhibitions extends Model
             array(
                 'fields' => '*.*.*.*',
                 'filter[exhibition_status][eq]' => $status,
+                'filter[status][eq]' => 'published',
                 'meta' => '*',
                 'sort' => $sort,
                 'limit' => $limit
@@ -65,6 +67,7 @@ class Exhibitions extends Model
             array(
                 'fields' => '*.*.*.*',
                 'filter[featured_home][eq]' => 'yes',
+                'filter[status][eq]' => 'published',
                 'meta' => 'result_count,total_count,type',
                 'sort' => $sort,
                 'limit' => $limit
@@ -153,6 +156,7 @@ class Exhibitions extends Model
                 'fields' => '*.*.*.*',
                 'filter[exhibition_status][eq]' => $status,
                 'meta' => 'result_count,total_count,type',
+                'filter[status][eq]' => 'published',
                 'sort' => $sort,
                 'limit' => $limit
             )


### PR DESCRIPTION
Added `filter[status][eq] = 'published'` to Directus queries for exhibitions to prevent non-published exhibitions from appearing on the what's on page. It also now 404's on non-published detail pages for these exhibitions.