### PR TITLE
hotfix/staff-refresh

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -75,6 +75,8 @@ class Kernel extends ConsoleKernel
         # Clear sessions/shopify
         $schedule->call('App\Http\Controllers\solrImportController@shopifyRefresh')->cron('1 */12 * * */3');
         $schedule->call('App\Http\Controllers\solrImportController@sessionsRefresh')->cron('1 */12 * * */3');
+        # Clear staff profiles
+        $schedule->call('App\Http\Controllers\solrImportController@staffRefresh')->cron('0 2 * * *');
         # Sitemap generation
         $schedule->command('sitemap:generate')->daily();
         # Long form

--- a/app/Http/Controllers/solrImportController.php
+++ b/app/Http/Controllers/solrImportController.php
@@ -566,6 +566,20 @@ class solrImportController extends Controller
     }
 
     /**
+     * Refresh the Solr index for staff profiles.
+     *
+     * @return Result|ResultInterface
+     */
+    public function staffRefresh(): Result|ResultInterface
+    {
+        $configSolr = Config::get('solarium');
+        $client = new Client(new Curl(), new EventDispatcher(), $configSolr);
+        $delete = $client->createUpdate();
+        $delete->addDeleteQuery('contentType:staff_profile');
+        $delete->addCommit();
+        return $client->update($delete);
+    }
+    /**
      * @return ResultInterface|Result
      * @throws ApiException
      * @throws CurlException


### PR DESCRIPTION
Added staffRefresh function to clear out old stubborn staff profiles from the Solr index.

I believe we should be able to trigger this to run manually using tinker.