### PR TITLE
Update php.yml

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
The CI GitHib actions are failing due to a deprecated version of the actions/cache, this was v2 now updated to v4.