### PR TITLE
Add if check to associated curators to account for rogue deleted entries / deactivated curators

### DIFF
--- a/resources/views/includes/elements/exhibitions/curators.blade.php
+++ b/resources/views/includes/elements/exhibitions/curators.blade.php
@@ -5,10 +5,12 @@
         <h3 class="mb-3">Curators and experts behind this exhibition</h3>
         <div class="row">
             @foreach($exhibition['associated_curators'] as $curator)
-            <x-image-card :altTag="$curator['staff_profiles_id']['display_name']"
-                :title="$curator['staff_profiles_id']['display_name']"
-                :image="$curator['staff_profiles_id']['profile_image']" :route="'research-profile'"
-                :params="[$curator['staff_profiles_id']['slug']]"></x-image-card>
+                @if($curator['staff_profiles_id'])
+                    <x-image-card :altTag="$curator['staff_profiles_id']['display_name']"
+                        :title="$curator['staff_profiles_id']['display_name']"
+                        :image="$curator['staff_profiles_id']['profile_image']" :route="'research-profile'"
+                        :params="[$curator['staff_profiles_id']['slug']]"></x-image-card>
+                @endif
             @endforeach
             @foreach($exhibition['external_curators'] as $curator)
             <x-associated-curator :curator="$curator"></x-associated-curator>


### PR DESCRIPTION
This PR fixes the issue we found on the black-atlantic exhibition where a missing / deleted / deactivated curator that was previously credited to that exhibition was making the page error.

It does this by adding a check for the 'staff_profile_id' array key which was null on the offending curator profile.

This has been tested on a local version of the frontend that reads from the production database.