### PR TITLE
Fix anchor links issue

### DIFF
--- a/resources/views/layouts/visitus.blade.php
+++ b/resources/views/layouts/visitus.blade.php
@@ -23,12 +23,19 @@
                         $components = $page['page_components'];
                     }
 
+                    // dd($components);
+
                     foreach($components as $component) {
-                        $component = is_array(array_values($component)[1]) ? array_values($component)[1][0] : null;
+                        // Each array has metadata added by directus - the following filters it to just the component data
+                        foreach($component as $item) {
+                            if(is_array($item)) {
+                                $component = $item[0];
+                            }
+                        }
                         if($component && !empty($component['heading'])) {
                             $heading = $component['heading'];
                         }
-                        if(!empty($heading) && !empty($component['include_in_anchor_links']) && $component['include_in_anchor_links']) {
+                        if(!empty($heading) && !empty($component['include_in_anchor_links']) && $component['include_in_anchor_links'] == true) {
                             // label, anchor_id
                             array_push($anchor_menu, array(
                                 'label' => $heading,
@@ -37,6 +44,7 @@
                         }
                     }
                 @endphp
+                {{-- @dd($components) --}}
                 @include('visit.components.hero')
                 @include('includes.structure.breadcrumb', ['class' => 'col-md-12 shadow-sm p-3 mx-auto'])
                 @include('visit.components.anchor-navigation', [


### PR DESCRIPTION
This pull request fixes the anchor links issue where only some were pulling through to the anchor links navigation when their `include_in_anchor_links` value was set to `true`.

The problem was that when creating the accordion sections, the content editor (in this case, me) had accidentally clicked to add an item to the "Accordion Component" item in the "Page Components" repeater.

This ***did*** remove the content from the array, but instead of deleting its array item entirely, it was simply set to null, so it became array item 1, which was what the code was looking for as it's reference for the fields.

The accordion sections that were created ***without*** this clerical error retained the `accordion_section` as array item 1, so that's why they were working.

I rejigged the way it looks for the component data by introducing a loop that goes through the array, and sets the `$component` variable to only the array item that is itself an array (As this only happens with the repeater item data), which seemed to fix the issue.