### PR TITLE
Replace terms-of-use link in footer with terms-and-conditions

### DIFF
--- a/resources/views/includes/structure/footer.blade.php
+++ b/resources/views/includes/structure/footer.blade.php
@@ -114,8 +114,8 @@
                                 API</a>
                         </li>
                         <li>
-                            <a href="{{ route('landing-section', ['about-us', 'terms-of-sale'])}}"
-                                aria-label="Terms of sale for tickets">Terms of sale</a>
+                            <a href="{{ route('landing-section', ['about-us', 'terms-and-conditions'])}}"
+                                aria-label="Terms and Conditions">Terms & Conditions</a>
                         </li>
 
                         <li>


### PR DESCRIPTION
This pull request addresses the issues raised in ticket #15233 https://studio24.zendesk.com/agent/tickets/15233 - the "terms-of-sale" page no longer exists within the CMS and the client has requested the link be replaced with one to the "terms-and-conditions" page.