### PR TITLE
Add case for exhibition files in new banner component

### DIFF
--- a/resources/views/home/components/banner.blade.php
+++ b/resources/views/home/components/banner.blade.php
@@ -11,6 +11,8 @@
 
     if(isset($settings)) {
         $image_source = $settings['component_images'];
+    } elseif(isset($exhibition)) {
+        $image_source = $exhibition['exhibition_files'];
     }
 
     if(isset($banner['image']) && isset($image_source)) {


### PR DESCRIPTION
This Pull Request solves an issue raised in ticket #15296 in Zendesk, adding a condition for images being in the `exhibition_files` collection by checking for `exhibition_file_id` when looking for the image source.

This has been tested on staging by myself and the client, and has been approved by the client for deployment to production