### PR TITLE
Add conditional for parent_page on grid component cards

### DIFF
--- a/resources/views/support/components/grid.blade.php
+++ b/resources/views/support/components/grid.blade.php
@@ -88,6 +88,25 @@
                         $image_asset_url =
                             'https://fitz-content.studio24.dev/fitz-website/assets/Families 2.jpg?key=exhibition';
                     }
+
+                    // Card links
+                    $card_link = null;
+
+                    // First check if the card has a parent page assigned to it
+                    if(isset($card['parent_page'])) {
+                        $parent_page = $card['parent_page'];
+                        $card_link = '/' . $parent_page['slug'] . '/' . $card['slug'];
+                    }
+                    /* 
+                    If not, and the card has a slug, 
+                    use the page_root in the URL and append the slug to the end of that
+                    
+                    For example, if we're on the visit us page it would be:
+                    https://[environment_here]/plan-your-visit/[slug of page here]
+                    */ 
+                    elseif(isset($card['slug'])) {
+                        $card_link = $page_root . '/' . $card['slug'];
+                    }
                 @endphp
                 @include('support.components.card', [
                     'image_asset_url' => $image_asset_url,
@@ -97,7 +116,7 @@
                     'missing_image_url' =>
                         'https://fitz-content.studio24.dev/fitz-website/assets/Families 2.jpg?key=exhibition',
                     'heading' => $card['title'] ?? null,
-                    'card_link' => isset($card['slug']) ? $page_root . '/' . $card['slug'] : null,
+                    'card_link' => $card_link,
                     'sub_heading' => null,
                     'body' => null,
                 ])


### PR DESCRIPTION
This Pull Request implements a solution to Zendesk ticket [15344](https://studio24.zendesk.com/agent/tickets/15344).

It adds a check for the 'parent_page' field in the relevant subpage, and if it's populated, the href of the grid card becomes:
/[parent page]/[current page slug].

Otherwise, it checks for the slug of the slug and uses the page root (i.e https://www.fitzmuseum.ac.uk/) then adds the slug of the page being linked to in the card to the end

To test this: 
1. Go to the Home Page Config collection in Directus (there should only be one entry in this collection)
2. Scroll down to the Page Listing heading and add pages to the Custom Page Listing
3. Clear cache if needed and test on the homepage

This work has been tested on a local environment connected to the staging Directus instance, and tested by the client on staging. This has gained approval from the client to deploy to production