### PR TITLE
Quick fix for duplicate function error.

### DIFF
--- a/resources/views/support/components/image-gallery.blade.php
+++ b/resources/views/support/components/image-gallery.blade.php
@@ -24,7 +24,7 @@
                 $image_source = $exhibition['exhibition_files'];
             }
 
-            function getImageData($image_source, $image_id)
+            function getGalleryImageData($image_source, $image_id)
             {
                 $image_asset = [];
                 if (!empty($image_id)) {
@@ -64,7 +64,7 @@
                             <li class="splide__slide">
                                 @php
                                     if(!empty($image['image_id'])) {
-                                        $current_image = getImageData($image_source, $image['image_id']);
+                                        $current_image = getGalleryImageData($image_source, $image['image_id']);
                                     } else {
                                         $current_image = $image;
                                     }


### PR DESCRIPTION
Quick fix for duplicate function error on pages that use both image-gallery and FAQ components. Long term this ideally needs refactoring to move the function to a helper with both components referencing that instead of defining their own.